### PR TITLE
新商品から表示を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | Column                  | Type        | Options                             |
 | ----------------------- | ----------- | ----------------------------------- |
 | postal_code             | string      | null: false                         |
-| precture_id             | integer     | null: false                         |
+| prefecture_id           | integer     | null: false                         |
 | city                    | string      | null: false                         |
 | house_number            | string      | null: false                         |
 | buliding_name           | string      |                                     |

--- a/app/assets/stylesheets/products/index.scss
+++ b/app/assets/stylesheets/products/index.scss
@@ -241,7 +241,7 @@ a {
   width: 100vw;
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: space-around;
 }
 
 .item-lists>.list {
@@ -249,7 +249,6 @@ a {
   padding: 1vw;
   background-color: #FFF;
 }
-
 
 .item-img-content {
   position: relative;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,7 @@ class ProductsController < ApplicationController
 
   def index
     @product = Product.all.order('created_at DESC')
+    # binding.pry
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @product = Product.all
+    @product = Product.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,7 +3,6 @@ class ProductsController < ApplicationController
 
   def index
     @product = Product.all.order('created_at DESC')
-    # binding.pry
   end
 
   def new

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,29 +1,27 @@
-<ul class='item-lists'>  
-  <li class='list'>
-    <%= link_to "#" do %>
-    <%# image_tag(product.image), %>
-    <div class='item-img-content'>
-      <%= image_tag product.image, class: "item-img" %>
+<li class='list'>
+  <%= link_to "#" do %>
+  <%# image_tag(product.image), %>
+  <div class='item-img-content'>
+    <%= image_tag product.image, class: "item-img" %>
 
-      <%# 商品が売れていればsold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れていればsold outを表示しましょう %>
-
+    <%# 商品が売れていればsold outを表示しましょう %>
+    <div class='sold-out'>
+      <span>Sold Out!!</span>
     </div>
-    <div class='item-info'>
-      <h3 class='item-name'>
-        <%= product.name %>
-      </h3>
-      <div class='item-price'>
-        <span><%= product.price %>円<br><%= product.delivery_fee.name %></span>
-        <div class='star-btn'>
-          <%= image_tag "star.png", class:"star-icon" %>
-          <span class='star-count'>0</span>
-        </div>
+    <%# //商品が売れていればsold outを表示しましょう %>
+
+  </div>
+  <div class='item-info'>
+    <h3 class='item-name'>
+      <%= product.name %>
+    </h3>
+    <div class='item-price'>
+      <span><%= product.price %>円<br><%= product.delivery_fee.name %></span>
+      <div class='star-btn'>
+        <%= image_tag "star.png", class:"star-icon" %>
+        <span class='star-count'>0</span>
       </div>
     </div>
-    <% end %>
-  </li>
-</ul>
+  </div>
+  <% end %>
+</li>

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,6 +1,5 @@
 <li class='list'>
   <%= link_to "#" do %>
-  <%# image_tag(product.image), %>
   <div class='item-img-content'>
     <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -126,11 +126,33 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
 
     <ul class='item-lists'>
-      <%# 部分テンプレートによる商品一覧を表示 %>
-      <%= render partial: "product", collection: @product%>
+      <%# 出品商品がある場合 %>
+      <% if @product != nil %>
+          <%# 部分テンプレートによる商品一覧を表示 %>
+          <%= render partial: "product", collection: @product%>
+
+      <%# 商品がない場合のダミーを表示 %>
+      <% else %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        </li>
+      <%end%>
     </ul>
   </div>
-  
 </div>
 <%= link_to(new_product_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -124,9 +124,11 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    
+
+    <ul class='item-lists'>
       <%# 部分テンプレートによる商品一覧を表示 %>
       <%= render partial: "product", collection: @product%>
+    </ul>
   </div>
   
 </div>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,7 +127,7 @@
 
     <ul class='item-lists'>
       <%# 出品商品がある場合 %>
-      <% if @product != nil %>
+      <% if @product.present? %>
           <%# 部分テンプレートによる商品一覧を表示 %>
           <%= render partial: "product", collection: @product%>
 


### PR DESCRIPTION
# WHAT
商品一覧表示機能の実装

# WHY
商品一覧を表示するため

# 機能確認
　・ログアウト状態でも商品一覧ページを見ることができる
　・出品した商品の一覧表示ができている
　・「画像/価格/商品名」の３つの情報について表示できている
　・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっている(現時点未実装)
　　https://gyazo.com/59ccd3d5de76066d98152de8b4023d95
　
　・上から、出品された日時が新しい順に表示されること
　　https://gyazo.com/2c0433c566c938a800a91e65c67c7bf1