### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @product = Product.all.order('created_at DESC')
@@ -16,6 +16,10 @@ class ProductsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @product = Product.find(params[:id])
   end
 
   private

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,5 +1,5 @@
 <li class='list'>
-  <%= link_to "#" do %>
+  <%= link_to product_path(product.id) do %>
   <div class='item-img-content'>
     <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -134,7 +134,7 @@
       <%# 商品がない場合のダミーを表示 %>
       <% else %>
         <li class='list'>
-          <%= link_to '#' do %>
+          <%= link_to root_path do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,25 +16,27 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥#{@product.price}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @product.delivery_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <%# ログインしている場合 %>
+  <% if user_signed_in? %>
+    <%# ログインユーザーと出品しているユーザーが同一人物の場合 %>
+    <% if current_user.id == @product.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
+    <%# 同一人物ではない場合の場合 %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+  <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%=  @product.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%=  @product.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%=  @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%=  @product.delivery_days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'products#index'
-  resources :products, only: [:index, :new, :create]
+  resources :products, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# WHAT
商品詳細表示機能の実装

# WHY
商品詳細表示をするため

# 機能確認
　ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
　商品出品時に登録した情報が見られるようになっていること
　ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと(未実装)
　https://gyazo.com/921cdac0591cbd256d379ee7b074469a

　ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
　https://gyazo.com/b5fa8f689c902cdd786a7f0bca72a6d2

　ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
　ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
　https://gyazo.com/98c026ed8c2456cb2c79e0ea565dd562